### PR TITLE
uppercasing strips first character

### DIFF
--- a/src/vmod_redis.c
+++ b/src/vmod_redis.c
@@ -168,7 +168,7 @@ vmod_command(const struct vrt_ctx *ctx, struct vmod_priv *vcl_priv, VCL_STRING n
         AN(command);
         char *ptr = command;
         while (*ptr) {
-            toupper(*ptr);
+            *ptr = toupper(*ptr);
             ptr++;
         }
 


### PR DESCRIPTION
test02.vtc fails because any call to vmod_command() ends up removing first character making calls in vmod_execute() to fail
