### PR TITLE
Fix typo master (v4.0) branch where 'sp' was used in vmod_array_reply_is_ instead of 'ctx'

### DIFF
--- a/src/vmod_redis.c
+++ b/src/vmod_redis.c
@@ -531,7 +531,7 @@ vmod_get_array_reply_length(const struct vrt_ctx *ctx)
 VCL_BOOL \
 vmod_array_reply_is_ ## lower(const struct vrt_ctx *ctx, VCL_INT index) \
 { \
-    thread_state_t *state = get_thread_state(sp, 0); \
+    thread_state_t *state = get_thread_state(ctx, 0); \
     return \
         (state->reply != NULL) && \
         (state->reply->type == REDIS_REPLY_ARRAY) && \


### PR DESCRIPTION
'make' was failing in the master branch (v4.0) because of a typo, fixed the typo and tested successfully
