### PR TITLE
Example missing type

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,6 +104,7 @@ Single server
         # per Varnish worker thread.
         new db = redis.db(
             location="192.168.1.100:6379",
+            type=master,
             connection_timeout=500,
             shared_connections=false,
             max_connections=1);


### PR DESCRIPTION
Without it varnish fails to start with errors:

```
 * Checking syntax varnish                                                                                                                                                                                                                                             [fail] 
Error:
Message from VCC-compiler:
Argument 'type' missing
('/etc/varnish/default.vcl' Line 18 Pos 26)
        max_connections=1);
```