### PR TITLE
Implemented serverless database initialization.

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -21,7 +21,8 @@
 enum REDIS_SERVER_ROLE {
     REDIS_SERVER_SLAVE_ROLE = 0,
     REDIS_SERVER_MASTER_ROLE = 1,
-    REDIS_SERVER_TBD_ROLE = 2
+    REDIS_SERVER_TBD_ROLE = 2,
+    REDIS_SERVER_UNKNOWN_ROLE // Better keep this one last and unspecified!
 };
 
 enum REDIS_SERVER_LOCATION_TYPE {
@@ -382,7 +383,13 @@ redisReply *redis_execute(
     unsigned max_retries, unsigned argc, const char *argv[], unsigned *retries,
     redis_server_t *server, unsigned asking, unsigned master, unsigned slot);
 
+redis_server_t * find_redis_server(
+    VRT_CTX, struct vmod_redis_db *db, const char *location, enum REDIS_SERVER_ROLE role,
+    unsigned *iweight, enum REDIS_SERVER_ROLE *irole);
 redis_server_t * unsafe_add_redis_server(
     VRT_CTX, struct vmod_redis_db *db, const char *location, enum REDIS_SERVER_ROLE role);
+
+enum REDIS_SERVER_ROLE find_redis_server_role(
+    VCL_ENUM type);
 
 #endif

--- a/src/vmod_redis.c
+++ b/src/vmod_redis.c
@@ -401,8 +401,7 @@ vmod_db__init(
     AZ(*db);
 
     // Check input.
-    if ((location != NULL) && (strlen(location) > 0) &&
-        (connection_timeout >= 0) &&
+    if ((connection_timeout >= 0) &&
         (connection_ttl >= 0) &&
         (command_timeout >= 0) &&
         (max_command_retries >= 0) &&
@@ -422,57 +421,42 @@ vmod_db__init(
         // Extract role & clustering flag.
         unsigned clustered;
         enum REDIS_SERVER_ROLE role;
-        if (strcmp(type, "master") == 0) {
-            role = REDIS_SERVER_MASTER_ROLE;
-            clustered = 0;
-        } else if (strcmp(type, "slave") == 0) {
-            role = REDIS_SERVER_SLAVE_ROLE;
-            clustered = 0;
-        } else if (strcmp(type, "auto") == 0) {
-            role = REDIS_SERVER_TBD_ROLE;
-            clustered = 0;
-        } else if (strcmp(type, "cluster") == 0) {
-            role = REDIS_SERVER_TBD_ROLE;
-            clustered = 1;
-        } else {
+        role = find_redis_server_role(type);
+        if (role == REDIS_SERVER_UNKNOWN_ROLE) {
             WRONG("Invalid server type value.");
         }
+        clustered = role == REDIS_SERVER_TBD_ROLE;
 
         // Create new database instance.
-        struct vmod_redis_db *instance = new_vmod_redis_db(
+        *db = new_vmod_redis_db(
             config, vcl_name, connection_timeout_tv, connection_ttl,
             command_timeout_tv, max_command_retries, shared_connections, max_connections,
             password, sickness_ttl, clustered, max_cluster_hops);
 
-        // Add initial server.
+        if ((location != NULL) && (strlen(location) > 0)) {
+            vmod_db_add_server(ctx, *db, location, type);
+
+            // Play nice and don't change interface: original interface did free memory
+            // and nulified db when unable to add redis server.
+            unsigned iweight;
+            enum REDIS_SERVER_ROLE irole;
+            if (!find_redis_server(ctx, *db, location, role, &iweight, &irole)) {
+                free_vmod_redis_db(*db);
+                *db = NULL;
+                return;
+            }
+        }
+
+        // Register & return the new database instance.
+        database_t *database = new_database(*db);
         Lck_Lock(&config->mutex);
-        Lck_Lock(&instance->mutex);
-        redis_server_t *server = unsafe_add_redis_server(ctx, instance, location, role);
-        Lck_Unlock(&instance->mutex);
+        VTAILQ_INSERT_TAIL(&config->dbs, database, list);
         Lck_Unlock(&config->mutex);
 
-        // Do not continue if we failed to create the server instance.
-        if (server != NULL) {
-            // Launch initial discovery of the cluster topology?
-            if (instance->cluster.enabled) {
-                discover_cluster_slots(ctx, instance, server);
-            }
-
-            // Register & return the new database instance.
-            database_t *database = new_database(instance);
-            Lck_Lock(&config->mutex);
-            VTAILQ_INSERT_TAIL(&config->dbs, database, list);
-            Lck_Unlock(&config->mutex);
-            *db = instance;
-
-            // Log event.
-            REDIS_LOG_INFO(ctx,
-                "New database instance registered (db=%s)",
-                instance->name);
-        } else {
-            free_vmod_redis_db(instance);
-            *db = NULL;
-        }
+        // Log event.
+        REDIS_LOG_INFO(ctx,
+            "New database instance registered (db=%s)",
+            (*db)->name);
     }
 }
 
@@ -514,28 +498,29 @@ VCL_VOID
 vmod_db_add_server(
     VRT_CTX, struct vmod_redis_db *db, VCL_STRING location, VCL_ENUM type)
 {
-    if ((location != NULL) && (strlen(location) > 0) &&
-        ((!db->cluster.enabled || strcmp(type, "cluster") == 0))) {
+    if ((location != NULL) && (strlen(location) > 0)) {
         // Extract role.
         enum REDIS_SERVER_ROLE role;
-        if (strcmp(type, "master") == 0) {
-            role = REDIS_SERVER_MASTER_ROLE;
-        } else if (strcmp(type, "slave") == 0) {
-            role = REDIS_SERVER_SLAVE_ROLE;
-        } else if (strcmp(type, "auto") == 0) {
-            role = REDIS_SERVER_TBD_ROLE;
-        } else if (strcmp(type, "cluster") == 0) {
-            role = REDIS_SERVER_TBD_ROLE;
-        } else {
+        role = find_redis_server_role(type);
+        if (role == REDIS_SERVER_UNKNOWN_ROLE) {
             WRONG("Invalid server type value.");
         }
 
         // Add server.
         Lck_Lock(&db->config->mutex);
         Lck_Lock(&db->mutex);
-        unsafe_add_redis_server(ctx, db, location, role);
+        redis_server_t *server = unsafe_add_redis_server(ctx, db, location, role);
         Lck_Unlock(&db->mutex);
         Lck_Unlock(&db->config->mutex);
+
+        // Launch initial discovery of the cluster topology, if we have
+        // been able to add our first redis server, this is a cluster and
+        // no initial discoveries have been launched so far.
+        if ((server != NULL) && (db->cluster.enabled) &&
+            ((db->stats.cluster.discoveries.total == 0) &&
+             (db->stats.cluster.discoveries.failed == 0))) {
+                discover_cluster_slots(ctx, db, server);
+        }
     }
 }
 

--- a/src/vmod_redis.vcc
+++ b/src/vmod_redis.vcc
@@ -66,7 +66,7 @@ Description
     has already been created calls to this function are silently ignored.
 
 $Object db(PRIV_VCL,
-    STRING location,
+    STRING location="",
     ENUM { master, slave, auto, cluster } type,
     INT connection_timeout=1000,
     INT connection_ttl=0,


### PR DESCRIPTION
 Using this feature one can easily automate the configuration of Redis clusters within a Varnish
configuration, using a configuration management tool.

The unsafe_add_redis_server() call has been removed from vmod_db__init() and
has been replaced by a call to vmod_db_add_server(). Also the initial
discovery of the cluster topology has been removed. This has been moved
to vmod_db_add_server().

A new find_redis_server_role() and find_redis_server() has been added. The
first converts the given type (string) to a role (enum) and the second
searches the list of servers for a given server. Both are used and can be
used at several places in the code in a generic way.

Care has been taken to keep the interface the same. Hence we free memory
and nulify the db when unable to add the given redis server during
database initialization.