### PR TITLE
Update libhiredis dependency for Debian Stretch

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,5 +14,5 @@ Standards-Version: 3.8.1
 
 Package: libvmod-redis
 Architecture: any
-Depends: varnish (>= 5.0.0), libhiredis0.10 (>= 0.11.0), libev4 (>= 4.15), ${shlibs:Depends}, ${misc:Depends}, ${Varnish:ABI}
+Depends: varnish (>= 5.0.0), libhiredis0.10 (>= 0.11.0) | libhiredis0.13 (>= 0.13.3), libev4 (>= 4.15), ${shlibs:Depends}, ${misc:Depends}, ${Varnish:ABI}
 Description: Redis VMOD for Varnish


### PR DESCRIPTION
Debian 9, which includes Varnish 5, uses `libhiredis0.13` rather than `libhiredis0.11`  so the dependencies in the control file needed updating to reflect this before the package would install.

I left `libhiredis0.10` in place as an alternative for anyone building on Jessie against Varnish 5.

I hope this is useful, or at least informative if you'd rather integrate this in a different fashion.