### PR TITLE
introduce get_array_reply() to represent arrays

### DIFF
--- a/src/tests/standalone.get_array.vtc
+++ b/src/tests/standalone.get_array.vtc
@@ -1,0 +1,59 @@
+varnishtest "Minimal test template"
+
+server s1 {} -start
+
+varnish v1 -arg "-p vsl_reclen=1024" -vcl+backend {
+    import ${vmod_redis};
+
+    sub vcl_init {
+        redis.subnets(
+            masks={""});
+
+        redis.sentinels(
+            locations={""},
+            period=0,
+            connection_timeout=500,
+            command_timeout=0);
+
+        new db = redis.db(
+            location="${redis_master1_ip}:${redis_master1_port}",
+            type=master,
+            connection_timeout=500,
+            connection_ttl=0,
+            command_timeout=0,
+            max_command_retries=0,
+            shared_connections=false,
+            max_connections=1,
+            password="",
+            sickness_ttl=0,
+            ignore_slaves=false,
+            max_cluster_hops=0);
+    }
+
+    sub vcl_recv {
+	return (synth(200));
+    }
+    sub vcl_synth {
+	db.command("LRANGE");
+	db.push("mylist");
+	db.push("0");
+	db.push("-1");
+	db.execute();
+
+        set resp.http.list = db.get_array_reply(", ");    
+    }
+} -start
+
+shell {
+	cat <<-EOF | redis-cli -h ${redis_master1_ip} -p ${redis_master1_port}
+		RPUSH mylist "hello"
+		RPUSH mylist "world"
+	EOF
+}
+
+client c1 {
+    txreq
+    rxresp
+
+    expect resp.http.list == "hello, world"
+} -run

--- a/src/vmod_redis.vcc
+++ b/src/vmod_redis.vcc
@@ -171,6 +171,11 @@ $Function INT get_array_reply_length(PRIV_VCL, PRIV_TASK, STRING db="")
 Description
     Proxied version of ``.get_array_reply_length()``.
 
+$Function STRING get_array_reply(PRIV_VCL, PRIV_TASK, sep = "\n", STRING db="")
+
+Description
+    Proxied version of ``.get_array_reply()``.
+
 $Function BOOL array_reply_is_error(PRIV_VCL, PRIV_TASK, INT index, STRING db="")
 
 Description
@@ -498,6 +503,13 @@ $Method INT .get_array_reply_length(PRIV_TASK)
 Return value
     If a previously executed Redis command using ``.execute()`` returned
     an array reply, this function returns the number of elements in that reply.
+
+$Method STRING .get_array_reply(PRIV_TASK, STRING sep = "\n")
+
+Return value
+    If a previously executed Redis command using ``.execute()`` returned
+    an array reply, this function returns a string representation of that reply,
+    joining the replies using the ``sep`` string.
 
 $Method BOOL .array_reply_is_error(PRIV_TASK, INT index)
 


### PR DESCRIPTION
Hi,

We have a use case were filter rules are pushed into `redis` and we want to retrieve a flat file to parse it in one go, so here's a patch to do this.

This targets `6.0` as this is the main platform at the moment, but if this gets merged I'll be happy to open a PR for `6.3`/`master` too.

I'm not experienced with `redis` so all feedback is more than welcome