### PR TITLE
Fix build under FreeBSD

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -11,6 +11,9 @@
 #include <hiredis/hiredis_ssl.h>
 #endif
 #include <arpa/inet.h>
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#endif
 
 #include "cache/cache.h"
 

--- a/src/vmod_redis.c
+++ b/src/vmod_redis.c
@@ -10,6 +10,9 @@
 #include <hiredis/hiredis_ssl.h>
 #endif
 #include <arpa/inet.h>
+#ifdef __FreeBSD__
+#include <sys/socket.h>
+#endif
 
 #include "cache/cache.h"
 #include "vsb.h"


### PR DESCRIPTION
`AF_INET* comes from sys/socket.h under FreeBSD.`