### PR TITLE
introduce .easy_command()

### DIFF
--- a/src/tests/standalone.easy-command.vtc
+++ b/src/tests/standalone.easy-command.vtc
@@ -1,0 +1,58 @@
+varnishtest "Tests command execution timeout"
+
+server s1 {
+   rxreq
+   txresp
+} -repeat 1 -start
+
+varnish v1 -arg "-p vsl_reclen=1024" -vcl+backend {
+    import ${vmod_redis};
+
+    sub vcl_init {
+        redis.subnets(
+            masks={""});
+
+        redis.sentinels(
+            locations={""},
+            period=0,
+            connection_timeout=500,
+            command_timeout=0);
+
+        new db = redis.db(
+            location="${redis_master1_ip}:${redis_master1_port}",
+            type=master,
+            connection_timeout=500,
+            connection_ttl=0,
+            command_timeout=0,
+            max_command_retries=0,
+            shared_connections=false,
+            max_connections=1,
+            password="",
+            sickness_ttl=0,
+            ignore_slaves=false,
+            max_cluster_hops=0);
+    }
+
+    sub vcl_deliver {
+        db.easy_command("SET", "easy-foo", "easy-hello");
+        set resp.http.Replied-1 = db.replied();
+        set resp.http.Reply-1 = db.get_reply();
+
+        db.easy_command("GET", "easy-foo");
+        set resp.http.Replied-2 = db.replied();
+        set resp.http.Reply-2 = db.get_reply();
+    }
+} -start
+
+client c1 {
+    txreq
+    rxresp
+
+    expect resp.http.Replied-1 == "true"
+    expect resp.http.Reply-1 == "OK"
+
+    expect resp.http.Replied-2 == "true"
+    expect resp.http.Reply-2 == "easy-hello"
+} -run
+
+varnish v1 -expect client_req == 1

--- a/src/vmod_redis.c
+++ b/src/vmod_redis.c
@@ -824,6 +824,27 @@ vmod_db_execute(
 }
 
 /******************************************************************************
+ * .easy_command();
+ *****************************************************************************/
+
+VCL_VOID
+vmod_db_easy_command(
+    VRT_CTX, struct vmod_redis_db *db, struct vmod_priv *vcl_priv,
+    struct vmod_priv *task_priv, VCL_STRANDS cmd)
+{
+    int i;
+
+    if (cmd->n)
+        vmod_db_command(ctx, db, task_priv, cmd->p[0]);
+
+    for (i = 1; i < cmd->n; i++)
+        vmod_db_push(ctx, db, task_priv, cmd->p[0]);
+
+    vmod_db_execute(ctx, db, vcl_priv, task_priv, 0);
+}
+
+
+/******************************************************************************
  * .replied();
  *****************************************************************************/
 

--- a/src/vmod_redis.vcc
+++ b/src/vmod_redis.vcc
@@ -527,6 +527,17 @@ Description
       and ``EVAL`` or ``EVALSHA`` command are submitted in order to avoid this
       counterintuitive scenario.
 
+$Method VOID .easy_command(PRIV_VCL, PRIV_TASK, STRANDS command_with_args)
+
+Arguments
+    The words composing the `redis` command, each as an individual argument.
+    Such as `db.easy_command("set", "foo", "hello");`
+Return value
+    VOID
+Description
+    Equivalent to calling, `.command()`, `.push()` (possibly multiple times),
+    then finally `.execute()` using a single command.
+
 $Method BOOL .replied(PRIV_TASK)
 
 Return value


### PR DESCRIPTION
Hi @carlosabalde!

the command/push/execute dance  got old fairly quickly, so I thought that the API would benefit from a simple way to execute a command with a single method.

The new test plagiarizes the timeout vtc, feel free to call me out on that one if you think it needs more coverage.

I wanted to keep the initial commit dead simple, so I haven't tried supporting the `timeout` or `master` arguments, which should be easy to do if we accept putting them as first optional arguments.

As an example, instead of writing:

```
db.command("set");
db.push("key1");
db.push("val1");
db.execute();
```

this allows to just write:

```
db.easy_command("set" + "key1" + "val1");
```

It's literally a 10-minutes job, so caution is advised when approving this request :-)