### PR TITLE
introduce .easy_execute() 2: electric boogaloo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,7 @@ import redis;
     Method VOID .retries(INT max_command_retries)
     Method VOID .push(STRING arg)
     Method VOID .execute(BOOL master=true)
+    Method VOID .easy_execute(STRING command, [STRING command_args...], BOOL master=true, INT command_timeout, INT max_command_retries)
 
     # Access to replies.
     Method BOOL .replied()
@@ -173,6 +174,9 @@ Single server
         db.push("foo");
         db.push("Hello world!");
         db.execute();
+
+        # Alternatively, the same can be achieved with one single command
+        db.easy_execute("SET", "foo", "Hello world!");
 
         # LUA scripting.
         db.command("EVAL");

--- a/src/tests/standalone.easy-command-timeout.vtc
+++ b/src/tests/standalone.easy-command-timeout.vtc
@@ -35,32 +35,32 @@ varnish v1 -arg "-p vsl_reclen=1024" -vcl+backend {
 
     sub vcl_deliver {
         # Fast command (no timeout).
-	db.easy_execute("SET", "foo", "hello", master = true);
+        db.easy_execute("SET", "foo", "hello", master = true);
         set resp.http.Replied-1 = db.replied();
         set resp.http.Reply-1 = db.get_reply();
 
         # Slow command (no timeout).
-	db.easy_execute("DEBUG", "sleep", "3", master = true);
+        db.easy_execute("DEBUG", "sleep", "3", master = true);
         set resp.http.Replied-2 = db.replied();
         set resp.http.Reply-2 = db.get_reply();
 
         # Fast command (1000 ms timeout).
-	db.easy_execute("SET", "foo", "hello", master = true, timeout = 1000);
+        db.easy_execute("SET", "foo", "hello", master = true, timeout = 1000);
         set resp.http.Replied-3 = db.replied();
         set resp.http.Reply-3 = db.get_reply();
 
         # Slow command (1000 ms timeout).
-	db.easy_execute("DEBUG", "sleep", "3", master = true, timeout = 1000);
+        db.easy_execute("DEBUG", "sleep", "3", master = true, timeout = 1000);
         set resp.http.Replied-4 = db.replied();
         set resp.http.Reply-4 = db.get_reply();
 
         # Fast command (no timeout).
-	db.easy_execute("SET", "foo", "hello", master = true);
+        db.easy_execute("SET", "foo", "hello", master = true);
         set resp.http.Replied-5 = db.replied();
         set resp.http.Reply-5 = db.get_reply();
 
         # Slow command (no timeout).
-	db.easy_execute("DEBUG", "sleep", "3", master = true);
+        db.easy_execute("DEBUG", "sleep", "3", master = true);
         set resp.http.Replied-6 = db.replied();
         set resp.http.Reply-6 = db.get_reply();
 

--- a/src/tests/standalone.easy-command-timeout.vtc
+++ b/src/tests/standalone.easy-command-timeout.vtc
@@ -1,0 +1,110 @@
+varnishtest "Tests easy_execution timeout"
+
+server s1 {
+   rxreq
+   txresp
+} -repeat 1 -start
+
+varnish v1 -arg "-p vsl_reclen=1024" -vcl+backend {
+    import ${vmod_redis};
+
+    sub vcl_init {
+        redis.subnets(
+            masks={""});
+
+        redis.sentinels(
+            locations={""},
+            period=0,
+            connection_timeout=500,
+            command_timeout=0);
+
+        new db = redis.db(
+            location="${redis_master1_ip}:${redis_master1_port}",
+            type=master,
+            connection_timeout=500,
+            connection_ttl=0,
+            command_timeout=0,
+            max_command_retries=0,
+            shared_connections=false,
+            max_connections=1,
+            password="",
+            sickness_ttl=0,
+            ignore_slaves=false,
+            max_cluster_hops=0);
+    }
+
+    sub vcl_deliver {
+        # Fast command (no timeout).
+	db.easy_execute("SET", "foo", "hello", master = true);
+        set resp.http.Replied-1 = db.replied();
+        set resp.http.Reply-1 = db.get_reply();
+
+        # Slow command (no timeout).
+	db.easy_execute("DEBUG", "sleep", "3", master = true);
+        set resp.http.Replied-2 = db.replied();
+        set resp.http.Reply-2 = db.get_reply();
+
+        # Fast command (1000 ms timeout).
+	db.easy_execute("SET", "foo", "hello", master = true, timeout = 1000);
+        set resp.http.Replied-3 = db.replied();
+        set resp.http.Reply-3 = db.get_reply();
+
+        # Slow command (1000 ms timeout).
+	db.easy_execute("DEBUG", "sleep", "3", master = true, timeout = 1000);
+        set resp.http.Replied-4 = db.replied();
+        set resp.http.Reply-4 = db.get_reply();
+
+        # Fast command (no timeout).
+	db.easy_execute("SET", "foo", "hello", master = true);
+        set resp.http.Replied-5 = db.replied();
+        set resp.http.Reply-5 = db.get_reply();
+
+        # Slow command (no timeout).
+	db.easy_execute("DEBUG", "sleep", "3", master = true);
+        set resp.http.Replied-6 = db.replied();
+        set resp.http.Reply-6 = db.get_reply();
+
+        # Stats.
+        set resp.http.db-stats = db.stats();
+        set resp.http.db-servers-total = db.counter("servers.total");
+        set resp.http.db-connections-total = db.counter("connections.total");
+        set resp.http.db-connections-dropped-error = db.counter("connections.dropped.error");
+        set resp.http.db-commands-total = db.counter("commands.total");
+        set resp.http.db-commands-error = db.counter("commands.error");
+        set resp.http.db-commands-failed = db.counter("commands.failed");
+        set resp.http.db-commands-noscript = db.counter("commands.noscript");
+    }
+} -start
+
+client c1 {
+    txreq
+    rxresp
+
+    expect resp.http.Replied-1 == "true"
+    expect resp.http.Reply-1 == "OK"
+
+    expect resp.http.Replied-2 == "true"
+    expect resp.http.Reply-2 == "OK"
+
+    expect resp.http.Replied-3 == "true"
+    expect resp.http.Reply-3 == "OK"
+
+    expect resp.http.Replied-4 == "false"
+    expect resp.http.Reply-4 == ""
+
+    expect resp.http.Replied-5 == "true"
+    expect resp.http.Reply-5 == "OK"
+
+    expect resp.http.Replied-6 == "true"
+    expect resp.http.Reply-6 == "OK"
+
+    expect resp.http.db-servers-total == "1"
+    expect resp.http.db-connections-total == "2"
+    expect resp.http.db-connections-dropped-error == "1"
+    expect resp.http.db-commands-total == "5"
+    expect resp.http.db-commands-failed == "1"
+    expect resp.http.db-commands-error == "0"
+    expect resp.http.db-commands-noscript == "0"
+} -run
+
+varnish v1 -expect client_req == 1

--- a/src/tests/standalone.proxied-methods.vtc
+++ b/src/tests/standalone.proxied-methods.vtc
@@ -82,6 +82,29 @@ varnish v1 -arg "-p vsl_reclen=1024" -vcl+backend {
         redis.execute(true, db="master1");
         set resp.http.Reply-4 = redis.get_reply(db="master1");
 
+	# same, with easy_execute
+        # SET (master1) -> GET (master1) -> GET (master2).
+        redis.use("master1");
+	redis.easy_execute("SET", "baz", "42");
+
+	redis.easy_execute("GET", "baz");
+        set resp.http.Reply-easy-1 = redis.get_reply();
+
+	redis.easy_execute("GET", "baz", db="master2", master = true);
+        set resp.http.Reply-easy-2 = redis.get_reply(db="master2");
+
+        # SET (master2) -> GET (master2) -> GET (master1).
+        redis.use("master2");
+	redis.easy_execute("SET", "qux", "42");
+
+        redis.command("GET");
+	redis.easy_execute("GET", "qux");
+        set resp.http.Reply-easy-3 = redis.get_reply();
+
+	redis.easy_execute("GET", "qux", db="master1");
+        set resp.http.Reply-easy-4 = redis.get_reply(db="master1");
+
+
         # Stats.
         set resp.http.master1-stats = redis.stats(db="master1");
         set resp.http.master1-servers-total = redis.counter("servers.total", db="master1");
@@ -113,17 +136,23 @@ client c1 {
     expect resp.http.Reply-3 == "Hello world!"
     expect resp.http.Reply-4 == ""
 
+    expect resp.http.Reply-easy-1 == "42"
+    expect resp.http.Reply-easy-2 == ""
+
+    expect resp.http.Reply-easy-3 == "42"
+    expect resp.http.Reply-easy-4 == ""
+
     expect resp.http.master1-servers-total == "1"
-    expect resp.http.master1-connections-total == "2"
-    expect resp.http.master1-connections-dropped-overflow == "1"
-    expect resp.http.master1-commands-total == "3"
+    expect resp.http.master1-connections-total == "3"
+    expect resp.http.master1-connections-dropped-overflow == "2"
+    expect resp.http.master1-commands-total == "6"
     expect resp.http.master1-commands-error == "0"
     expect resp.http.master1-commands-noscript == "0"
 
     expect resp.http.master2-servers-total == "1"
-    expect resp.http.master2-connections-total == "1"
-    expect resp.http.master2-connections-dropped-overflow == "1"
-    expect resp.http.master2-commands-total == "3"
+    expect resp.http.master2-connections-total == "2"
+    expect resp.http.master2-connections-dropped-overflow == "2"
+    expect resp.http.master2-commands-total == "6"
     expect resp.http.master2-commands-error == "0"
     expect resp.http.master2-commands-noscript == "0"
 } -run

--- a/src/tests/standalone.proxied-methods.vtc
+++ b/src/tests/standalone.proxied-methods.vtc
@@ -82,26 +82,26 @@ varnish v1 -arg "-p vsl_reclen=1024" -vcl+backend {
         redis.execute(true, db="master1");
         set resp.http.Reply-4 = redis.get_reply(db="master1");
 
-	# same, with easy_execute
+        # same, with easy_execute
         # SET (master1) -> GET (master1) -> GET (master2).
         redis.use("master1");
-	redis.easy_execute("SET", "baz", "42");
+        redis.easy_execute("SET", "baz", "42");
 
-	redis.easy_execute("GET", "baz");
+        redis.easy_execute("GET", "baz");
         set resp.http.Reply-easy-1 = redis.get_reply();
 
-	redis.easy_execute("GET", "baz", db="master2", master = true);
+        redis.easy_execute("GET", "baz", db="master2", master = true);
         set resp.http.Reply-easy-2 = redis.get_reply(db="master2");
 
         # SET (master2) -> GET (master2) -> GET (master1).
         redis.use("master2");
-	redis.easy_execute("SET", "qux", "42");
+        redis.easy_execute("SET", "qux", "42");
 
         redis.command("GET");
-	redis.easy_execute("GET", "qux");
+        redis.easy_execute("GET", "qux");
         set resp.http.Reply-easy-3 = redis.get_reply();
 
-	redis.easy_execute("GET", "qux", db="master1");
+        redis.easy_execute("GET", "qux", db="master1");
         set resp.http.Reply-easy-4 = redis.get_reply(db="master1");
 
 

--- a/src/vmod_redis.c
+++ b/src/vmod_redis.c
@@ -824,6 +824,54 @@ vmod_db_execute(
 }
 
 /******************************************************************************
+ * .easy_execute();
+ *****************************************************************************/
+
+#define HANDLE_ARG(N) 						\
+    if (args->valid_cmd_arg ## N) {  				\
+        vmod_db_push(ctx, db, args->task_priv, args->cmd_arg ## N);	\
+    }
+
+/* we need this twice, with two different arg structures:
+ * - one exposed directly by the vcc
+ * - the other will be used by the proxied version
+ * and sadly we can't use VMOD_PROXIED_METHOD because of this 
+ */
+
+#define EASY_EXEC(name, arg_type)						\
+VCL_VOID									\
+name(										\
+    VRT_CTX, struct vmod_redis_db *db,						\
+    struct arg_type *args)							\
+{										\
+    AN(ctx);									\
+    AN(db);									\
+    AN(args);									\
+    AN(args->vcl_priv);								\
+    AN(args->task_priv);							\
+										\
+    vmod_db_command(ctx, db, args->task_priv, args->command);			\
+    HANDLE_ARG(1);   HANDLE_ARG(2);   HANDLE_ARG(3);   HANDLE_ARG(4);		\
+    HANDLE_ARG(5);   HANDLE_ARG(6);   HANDLE_ARG(7);   HANDLE_ARG(8);		\
+    HANDLE_ARG(9);   HANDLE_ARG(10);  HANDLE_ARG(11);  HANDLE_ARG(12);		\
+    HANDLE_ARG(13);  HANDLE_ARG(14);  HANDLE_ARG(15);  HANDLE_ARG(16);		\
+										\
+    if (args->valid_timeout) {							\
+        vmod_db_timeout(ctx, db, args->task_priv, args->timeout);		\
+    }										\
+    if (args->valid_retries) {							\
+        vmod_db_retries(ctx, db, args->task_priv, args->retries);		\
+    }										\
+										\
+    vmod_db_execute(ctx, db, args->vcl_priv, args->task_priv, args->master);	\
+}
+
+EASY_EXEC(vmod_db_easy_execute, arg_vmod_redis_db_easy_execute);
+EASY_EXEC(vmod_db_easy_execute_proxy, arg_vmod_redis_easy_execute);
+
+#undef HANDLE_ARG
+
+/******************************************************************************
  * .replied();
  *****************************************************************************/
 
@@ -1376,6 +1424,34 @@ vmod_use(
         REDIS_LOG_ERROR(ctx,
             "Failed to use database (db=%s)",
             db);
+    }
+}
+
+VCL_VOID
+vmod_easy_execute(VRT_CTX, struct arg_vmod_redis_easy_execute *args)
+{
+    struct vmod_redis_db *instance;
+
+    AN(ctx);
+    AN(args);
+    AN(args->vcl_priv);
+    AN(args->task_priv);
+
+    if ((args->db != NULL) && (strlen(args->db) > 0)) {
+        vcl_state_t *config = args->vcl_priv->priv;
+        instance = get_db_instance(ctx, config, args->db);
+    } else {
+        task_state_t *state = get_task_state(ctx, args->task_priv, 0);
+        instance = state->db;
+    }
+   
+    if (instance != NULL) {
+        return vmod_db_easy_execute_proxy(ctx, instance, args);
+    } else {
+        REDIS_LOG_ERROR(ctx,
+            "Database instance not available%s",
+            "");
+        return;
     }
 }
 

--- a/src/vmod_redis.c
+++ b/src/vmod_redis.c
@@ -827,9 +827,9 @@ vmod_db_execute(
  * .easy_execute();
  *****************************************************************************/
 
-#define HANDLE_ARG(N) 						\
-    if (args->valid_cmd_arg ## N) {  				\
-        vmod_db_push(ctx, db, args->task_priv, args->cmd_arg ## N);	\
+#define HANDLE_ARG(N)                                               \
+    if (args->valid_cmd_arg ## N) {                                 \
+        vmod_db_push(ctx, db, args->task_priv, args->cmd_arg ## N); \
     }
 
 /* we need this twice, with two different arg structures:
@@ -838,32 +838,32 @@ vmod_db_execute(
  * and sadly we can't use VMOD_PROXIED_METHOD because of this 
  */
 
-#define EASY_EXEC(name, arg_type)						\
-VCL_VOID									\
-name(										\
-    VRT_CTX, struct vmod_redis_db *db,						\
-    struct arg_type *args)							\
-{										\
-    AN(ctx);									\
-    AN(db);									\
-    AN(args);									\
-    AN(args->vcl_priv);								\
-    AN(args->task_priv);							\
-										\
-    vmod_db_command(ctx, db, args->task_priv, args->command);			\
-    HANDLE_ARG(1);   HANDLE_ARG(2);   HANDLE_ARG(3);   HANDLE_ARG(4);		\
-    HANDLE_ARG(5);   HANDLE_ARG(6);   HANDLE_ARG(7);   HANDLE_ARG(8);		\
-    HANDLE_ARG(9);   HANDLE_ARG(10);  HANDLE_ARG(11);  HANDLE_ARG(12);		\
-    HANDLE_ARG(13);  HANDLE_ARG(14);  HANDLE_ARG(15);  HANDLE_ARG(16);		\
-										\
-    if (args->valid_timeout) {							\
-        vmod_db_timeout(ctx, db, args->task_priv, args->timeout);		\
-    }										\
-    if (args->valid_retries) {							\
-        vmod_db_retries(ctx, db, args->task_priv, args->retries);		\
-    }										\
-										\
-    vmod_db_execute(ctx, db, args->vcl_priv, args->task_priv, args->master);	\
+#define EASY_EXEC(name, arg_type)                                            \
+VCL_VOID                                                                     \
+name(                                                                        \
+    VRT_CTX, struct vmod_redis_db *db,                                       \
+    struct arg_type *args)                                                   \
+{                                                                            \
+    AN(ctx);                                                                 \
+    AN(db);                                                                  \
+    AN(args);                                                                \
+    AN(args->vcl_priv);                                                      \
+    AN(args->task_priv);                                                     \
+                                                                             \
+    vmod_db_command(ctx, db, args->task_priv, args->command);                \
+    HANDLE_ARG(1);   HANDLE_ARG(2);   HANDLE_ARG(3);   HANDLE_ARG(4);        \
+    HANDLE_ARG(5);   HANDLE_ARG(6);   HANDLE_ARG(7);   HANDLE_ARG(8);        \
+    HANDLE_ARG(9);   HANDLE_ARG(10);  HANDLE_ARG(11);  HANDLE_ARG(12);       \
+    HANDLE_ARG(13);  HANDLE_ARG(14);  HANDLE_ARG(15);  HANDLE_ARG(16);       \
+                                                                             \
+    if (args->valid_timeout) {                                               \
+        vmod_db_timeout(ctx, db, args->task_priv, args->timeout);            \
+    }                                                                        \
+    if (args->valid_retries) {                                               \
+        vmod_db_retries(ctx, db, args->task_priv, args->retries);            \
+    }                                                                        \
+                                                                             \
+    vmod_db_execute(ctx, db, args->vcl_priv, args->task_priv, args->master); \
 }
 
 EASY_EXEC(vmod_db_easy_execute, arg_vmod_redis_db_easy_execute);

--- a/src/vmod_redis.vcc
+++ b/src/vmod_redis.vcc
@@ -143,6 +143,33 @@ $Function VOID execute(PRIV_VCL, PRIV_TASK, BOOL master=1, STRING db="")
 Description
     Proxied version of ``.execute()``.
 
+$Function VOID easy_execute(PRIV_VCL vcl_priv, PRIV_TASK task_priv,
+        STRING command,
+        [STRING cmd_arg1],
+        [STRING cmd_arg2],
+        [STRING cmd_arg3],
+        [STRING cmd_arg4],
+        [STRING cmd_arg5],
+        [STRING cmd_arg6],
+        [STRING cmd_arg7],
+        [STRING cmd_arg8],
+        [STRING cmd_arg9],
+        [STRING cmd_arg10],
+        [STRING cmd_arg11],
+        [STRING cmd_arg12],
+        [STRING cmd_arg13],
+        [STRING cmd_arg14],
+        [STRING cmd_arg15],
+        [STRING cmd_arg16],
+	[INT timeout],
+	[INT retries],
+	BOOL master = 1,
+	STRING db=""
+	)
+
+Description
+    Proxied version of ``.easy_execute()``.
+
 $Function BOOL replied(PRIV_VCL, PRIV_TASK, STRING db="")
 
 Description
@@ -526,6 +553,41 @@ Description
       internally forces ``master == true`` when Redis Cluster support is enabled
       and ``EVAL`` or ``EVALSHA`` command are submitted in order to avoid this
       counterintuitive scenario.
+
+$Method VOID .easy_execute(PRIV_VCL vcl_priv, PRIV_TASK task_priv,
+        STRING command,
+        [STRING cmd_arg1],
+        [STRING cmd_arg2],
+        [STRING cmd_arg3],
+        [STRING cmd_arg4],
+        [STRING cmd_arg5],
+        [STRING cmd_arg6],
+        [STRING cmd_arg7],
+        [STRING cmd_arg8],
+        [STRING cmd_arg9],
+        [STRING cmd_arg10],
+        [STRING cmd_arg11],
+        [STRING cmd_arg12],
+        [STRING cmd_arg13],
+        [STRING cmd_arg14],
+        [STRING cmd_arg15],
+        [STRING cmd_arg16],
+	[INT timeout],
+	[INT retries],
+	BOOL master = 1
+	)
+
+Arguments
+    The command argument is mandatory, followed with up to 16 arguments,
+    optionally ending with `timeout` (as passed to `.timeout()`) and/or
+    `retries` (as passed to `.retries()`) and/or `master` (`.execute()`).
+    For example: `db.easy_command("set", "foo", "hello", retries=3, master=true);`
+Return value
+    VOID
+Description
+    Equivalent to calling, `.command()`, `.push()` (possibly multiple times),
+    `.timeout()`, `.retries()` then finally `.execute()` using a single
+    command.
 
 $Method BOOL .replied(PRIV_TASK)
 

--- a/src/vmod_redis.vcc
+++ b/src/vmod_redis.vcc
@@ -579,14 +579,14 @@ $Method VOID .easy_execute(PRIV_VCL vcl_priv, PRIV_TASK task_priv,
 
 Arguments
     The command argument is mandatory, followed with up to 16 arguments,
-    optionally ending with `timeout` (as passed to `.timeout()`) and/or
-    `retries` (as passed to `.retries()`) and/or `master` (`.execute()`).
-    For example: `db.easy_command("set", "foo", "hello", retries=3, master=true);`
+    optionally ending with ``timeout`` (as passed to ``.timeout()``) and/or
+    ``retries`` (as passed to ``.retries()``) and/or ``master`` (``.execute()``).
+    For example: ``db.easy_command("set", "foo", "hello", retries=3, master=true);``
 Return value
     VOID
 Description
-    Equivalent to calling, `.command()`, `.push()` (possibly multiple times),
-    `.timeout()`, `.retries()` then finally `.execute()` using a single
+    Equivalent to calling, ``.command()``, ``.push()`` (possibly multiple times),
+    ``.timeout()``, ``.retries()`` then finally ``.execute()`` using a single
     command.
 
 $Method BOOL .replied(PRIV_TASK)

--- a/src/vmod_redis.vcc
+++ b/src/vmod_redis.vcc
@@ -161,11 +161,11 @@ $Function VOID easy_execute(PRIV_VCL vcl_priv, PRIV_TASK task_priv,
         [STRING cmd_arg14],
         [STRING cmd_arg15],
         [STRING cmd_arg16],
-	[INT timeout],
-	[INT retries],
-	BOOL master = 1,
-	STRING db=""
-	)
+        [INT timeout],
+        [INT retries],
+        BOOL master = 1,
+        STRING db=""
+        )
 
 Description
     Proxied version of ``.easy_execute()``.
@@ -572,10 +572,10 @@ $Method VOID .easy_execute(PRIV_VCL vcl_priv, PRIV_TASK task_priv,
         [STRING cmd_arg14],
         [STRING cmd_arg15],
         [STRING cmd_arg16],
-	[INT timeout],
-	[INT retries],
-	BOOL master = 1
-	)
+        [INT timeout],
+        [INT retries],
+        BOOL master = 1
+        )
 
 Arguments
     The command argument is mandatory, followed with up to 16 arguments,


### PR DESCRIPTION
Alright, let's try #48 again, with more experience and tests.

I'm not super happy with the `vcc` verbosity and the C redundancy, but the `vcl` code looks pretty good

I'll check if I can port that to `6.0-lts`, but `4.x` is out of the question as it doesn't support arg structs. `master` is trivial as you said and I'll also take care of it if this passes muster.

@carlosabalde, does that work for you?